### PR TITLE
fix: hours 수식 수정

### DIFF
--- a/src/components/SeoulMain.js
+++ b/src/components/SeoulMain.js
@@ -10,8 +10,8 @@ export default function SeoulMain() {
     let month = ('0' + (today.getMonth() + 1)).slice(-2);
     let day = ('0' + today.getDate()).slice(-2);
     let hours = (today.getHours() >= 12) ? (today.getHours() === 12) ?
-    "오후 "+today.getHours() : "오후 "+today.getHours()-12 : 
-    "오전 "+ today.getHours();
+    "오후 " + today.getHours() : "오후 " + (today.getHours()-12) : 
+    "오전 " + today.getHours();
 
    
     const mapData = require("./mapData.json").data;


### PR DESCRIPTION
## 반영 브랜치
time -> develop

## 변경 사항
(1) SeoulMain.js - hours 변수 구하는 식을 아주 약간 수정했습니다
문자 + 숫자 - 숫자 = 문자 - 숫자 순서로 처리해서 NaN 나온 거 같다고 슬쩍 추측해봅니다,,

## 테스트 결과
이제 1시도 잘 나와요
![image](https://user-images.githubusercontent.com/87255462/208345758-cbda6f4e-fb22-480c-b7a8-ea74ea7766b5.png)
