### PR TITLE
feat(Router): 페이지 추가 및 라우팅

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import Router from './Router';
+import './css/App.css';
+
+function App() {
+  return <Router />;
+}
+
+export default App;

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
+import Home from './pages/Home';
+import Notification from './pages/Notification';
+
+const Router = () => {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/notify" element={<Notification />} />
+      </Routes>
+    </BrowserRouter>
+  );
+};
+
+export default Router;

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -3,12 +3,3 @@
 * {
   font-family: 'Pretendard';
 }
-
-#service-title {
-  text-align: center;
-  margin: 20 0;
-}
-
-#service-title span {
-  color: #9e4242;
-}

--- a/src/css/Home.css
+++ b/src/css/Home.css
@@ -1,0 +1,8 @@
+#service-title {
+  text-align: center;
+  margin: 20 0;
+}
+
+#service-title span {
+  color: #9e4242;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import CheckBox from './components/CheckBox';
-import SeoulMap from './components/SeoulMap';
+import CheckBox from '../components/CheckBox';
+import SeoulMap from '../components/SeoulMap';
 
-import './css/App.css';
+import '../css/Home.css';
 
-function App() {
+const Home = () => {
   return (
     <div>
       <h4 id="service-title">
@@ -16,6 +16,6 @@ function App() {
       <CheckBox />
     </div>
   );
-}
+};
 
-export default App;
+export default Home;

--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Notification = () => {
+  return <div>알림 설정 페이지</div>;
+};
+
+export default Notification;


### PR DESCRIPTION
## 반영 브랜치
feature/router -> develop

## 변경 사항
* 알림 설정 페이지용 `Notification` 컴포넌트  추가
* 라우터 추가
* 기존 App 내용 ➡ `Home` 컴포넌트로 이동

  * css 파일도 분리 

## 테스트 결과
![test](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/0c6bda45-4087-4d58-b805-e8af5e89a252)
