### PR TITLE
refactor(Redux): 전역 상태 관련 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,10 @@
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.4.3",
         "react-scripts": "5.0.1",
+        "redux": "^4.2.1",
         "redux-devtools-extension": "^2.13.9",
         "redux-logger": "^3.0.6",
+        "redux-persist": "^6.0.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -15016,9 +15018,9 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -15038,6 +15040,14 @@
       "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
       "dependencies": {
         "deep-diff": "^0.3.5"
+      }
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
       }
     },
     "node_modules/redux-thunk": {
@@ -28357,9 +28367,9 @@
       }
     },
     "redux": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
@@ -28377,6 +28387,12 @@
       "requires": {
         "deep-diff": "^0.3.5"
       }
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
     },
     "redux-thunk": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.4.3",
     "react-scripts": "5.0.1",
+    "redux": "^4.2.1",
     "redux-devtools-extension": "^2.13.9",
     "redux-logger": "^3.0.6",
+    "redux-persist": "^6.0.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/CheckBox.js
+++ b/src/components/CheckBox.js
@@ -6,11 +6,7 @@ import SeoulMain from './SeoulMain.js';
 import '../css/message.css';
 
 export default function CheckBox() {
-  const currentState = useSelector((state) => {
-    return state;
-  });
-  const { clickCity } = currentState;
-
+  const currentCity = useSelector((state) => state.city);
   const titles = [
     { id: 0, name: '재난문자', path: 'emerMsg' },
     { id: 1, name: '지하철정보', path: 'metro' },
@@ -39,7 +35,7 @@ export default function CheckBox() {
 
   return (
     <div className="main-container">
-      {clickCity.cityID < 2 ? (
+      {currentCity.cityID < 2 ? (
         <SeoulMain />
       ) : (
         <>

--- a/src/components/MsgContent.js
+++ b/src/components/MsgContent.js
@@ -5,10 +5,7 @@ import axios from 'axios';
 import '../css/message.css';
 
 function MsgContent({ title, checkCount }) {
-  const currentState = useSelector((state) => {
-    return state;
-  });
-  const { clickCity } = currentState;
+  const currentCity = useSelector((state) => state.city);
 
   const [Msges, setMsges] = useState(null);
   const [, setLoading] = useState(false);
@@ -30,7 +27,7 @@ function MsgContent({ title, checkCount }) {
       const apiPath =
         title.path === 'metro'
           ? `https://api.bbiyong-bbiyong.seoul.kr//${title.path}/view`
-          : `https://api.bbiyong-bbiyong.seoul.kr/${title.path}/${clickCity.cityID}`;
+          : `https://api.bbiyong-bbiyong.seoul.kr/${title.path}/${currentCity.cityID}`;
       const response = await axios.get(apiPath);
 
       setMsges(response.data.data);
@@ -49,7 +46,7 @@ function MsgContent({ title, checkCount }) {
     return () => {
       setFade('');
     };
-  }, [clickCity, checkCount]);
+  }, [currentCity, checkCount]);
 
   const fillMsg = (target) => {
     if (title.path === 'emerMsg') return 'rgb(255, 155, 155)';

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,42 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 
+import { configureStore } from '@reduxjs/toolkit';
 import ReactDOM from 'react-dom/client';
+import { applyMiddleware } from 'redux';
+import { persistStore, persistReducer } from 'redux-persist';
+import { PersistGate } from 'redux-persist/integration/react';
+import storage from 'redux-persist/lib/storage';
+
+import App from './App.jsx';
+import { rootReducer } from './redux/reducer';
 
 import './css/index.css';
-import App from './App';
-import store from './redux/citySlice.js';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+
+const persistConfig = {
+  key: 'root',
+  storage,
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+const store = configureStore(
+  {
+    reducer: persistedReducer,
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware({ serializableCheck: false }),
+  },
+  applyMiddleware(),
+);
+const Persistor = persistStore(store);
+
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
+  <Provider store={store}>
+    <PersistGate loading={null} persistor={Persistor}>
       <App />
-    </Provider>
-  </React.StrictMode>,
+    </PersistGate>
+  </Provider>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/redux/citySlice.js
+++ b/src/redux/citySlice.js
@@ -1,8 +1,10 @@
-import { configureStore, createSlice } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+
+const cityInitialState = { index: null, cityName_KOR: '서울', cityName_ENG: 'seoul', cityID: 1 };
 
 const clickCity = createSlice({
   name: 'clickCity',
-  initialState: { index: null, cityName_KOR: '서울', cityName_ENG: 'seoul', cityID: 1 },
+  initialState: cityInitialState,
   reducers: {
     changeClickCity(state, action) {
       state.index = action.payload[0];
@@ -10,13 +12,9 @@ const clickCity = createSlice({
       state.cityName_ENG = action.payload[2];
       state.cityID = action.payload[3];
     },
+    clearCity: () => cityInitialState,
   },
 });
 
 export const { changeClickCity } = clickCity.actions;
-
-export default configureStore({
-  reducer: {
-    clickCity: clickCity.reducer,
-  },
-});
+export const citySliceReducer = clickCity.reducer;

--- a/src/redux/memberReducer.js
+++ b/src/redux/memberReducer.js
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const memberInitialState = {
+  id: 0,
+  signed: false,
+};
+
+const memberSlice = createSlice({
+  name: 'member',
+  initialState: memberInitialState,
+  reducers: {
+    setMember(state, action) {
+      state.id = action.payload.id;
+      state.signed = true;
+    },
+    clearMember: () => memberInitialState,
+  },
+});
+
+export const { setMember, clearMember } = memberSlice.actions;
+export const memberReducer = memberSlice.reducer;

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -1,0 +1,16 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers } from 'redux';
+
+import { citySliceReducer } from './citySlice';
+import { memberReducer } from './memberReducer';
+
+const rootReducer = combineReducers({
+  member: memberReducer,
+  city: citySliceReducer,
+});
+
+const Store = configureStore({
+  reducer: rootReducer,
+});
+
+export { Store, rootReducer };


### PR DESCRIPTION
## 반영 브랜치
feature/redux -> develop

## 변경 사항
* 전역으로 관리할 값 추가 (현재 로그인 중인 사용자 정보)

  * 에 따른 reducer 수정
  * redux-persist 도입

* "현재 클릭된 구"를 뜻하는 변수명 변경 (`currentState` -> `currentCity`)

예전 코드 보니까 수치스러워요 ㅈ진짜로

