### PR TITLE
refactor(Seoulmap): 현재 선택된 지역 파악 방식 변경

### DIFF
--- a/src/components/SeoulMap.js
+++ b/src/components/SeoulMap.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
 import axios from 'axios';
@@ -11,45 +11,22 @@ import { changeClickCity } from '../redux/citySlice';
 import '../css/SeoulMap.css';
 
 function SeoulMap() {
-  const navigate = useNavigate();
-
+  const currentCity = useSelector((state) => state.city);
   const dispatch = useDispatch();
+
+  const navigate = useNavigate();
 
   // eslint-disable-next-line global-require
   const mapData = require('../data/mapData.json').data;
   const [cities, setCities] = useState([]);
-
-  const [clickSeoul, setClickSeoul] = useState(true);
-  const [clickCityNum, setClickCityNum] = useState(null);
-
-  const cityRef = useRef();
-  const nameRef = useRef();
-
-  useEffect(() => {
-    async function fillCitiesData() {
-      const location = await axios.get('https://api.bbiyong-bbiyong.seoul.kr/location');
-      setCities(
-        mapData.map((city) => {
-          return {
-            properties: city,
-            length: location.data.data[city.SIG_ID],
-          };
-        }),
-      );
-    }
-    fillCitiesData();
-  }, []);
+  const [currentCityIndex, setCurrentCityIndex] = useState(currentCity.index);
 
   const selectCity = (e, ind) => {
-    let text = '';
-    if (cityRef.current.id === e.target.id && !clickSeoul) {
-      setClickSeoul(true);
-      setClickCityNum(null);
+    if (currentCity.ind === e.target.id || ind === undefined) {
+      setCurrentCityIndex(null);
       dispatch(changeClickCity([null, '서울', 'seoul', 1]));
-      text = '서울은?';
     } else {
-      setClickSeoul(false);
-      setClickCityNum(ind);
+      setCurrentCityIndex(ind);
       dispatch(
         changeClickCity([
           ind,
@@ -58,10 +35,7 @@ function SeoulMap() {
           cities[ind].properties.SIG_ID,
         ]),
       );
-      cityRef.current = e.target;
-      text = `${cityRef.current.id}는?`;
     }
-    nameRef.current.innerHTML = `지금 ${text}`;
   };
 
   const fillCity = (target) => {
@@ -91,27 +65,42 @@ function SeoulMap() {
     navigate('/notify');
   };
 
+  useEffect(() => {
+    async function fillCitiesData() {
+      const location = await axios.get('https://api.bbiyong-bbiyong.seoul.kr/location');
+      setCities(
+        mapData.map((city) => {
+          return {
+            properties: city,
+            length: location.data.data[city.SIG_ID],
+          };
+        }),
+      );
+    }
+    fillCitiesData();
+  }, []);
+
   return (
     <>
       <div id="map-container">
         <svg width="300" height="250" viewBox="0 0 800 600">
-          <rect width={60} height={25} x={50} y={-10} stroke="black" fill="white" />
+          <rect width={60} height={25} x={50} y={-10} stroke="black" fill="white" />{' '}
           <text x={125} y={8}>
             0~3
           </text>
-          <rect width={60} height={25} x={50} y={25} stroke="black" fill="#FBF0EF" />
+          <rect width={60} height={25} x={50} y={25} stroke="black" fill="#FBF0EF" />{' '}
           <text x={125} y={43}>
             4~6
           </text>
-          <rect width={60} height={25} x={50} y={60} stroke="black" fill="#FDE0E1" />
+          <rect width={60} height={25} x={50} y={60} stroke="black" fill="#FDE0E1" />{' '}
           <text x={125} y={78}>
             7~9
           </text>
-          <rect width={60} height={25} x={50} y={95} stroke="black" fill="#F7A7A5" />
+          <rect width={60} height={25} x={50} y={95} stroke="black" fill="#F7A7A5" />{' '}
           <text x={125} y={113}>
             10~12
           </text>
-          <rect width={60} height={25} x={50} y={130} stroke="black" fill="#F58987" />
+          <rect width={60} height={25} x={50} y={130} stroke="black" fill="#F58987" />{' '}
           <text x={125} y={148}>
             13 이상
           </text>
@@ -127,7 +116,7 @@ function SeoulMap() {
             알림 설정
           </text>
           {cities.map((city, ind) => (
-            <g key={ind} ref={cityRef}>
+            <g key={ind}>
               <path
                 key={ind}
                 id={city.properties.SIG_KOR_NM}
@@ -140,24 +129,27 @@ function SeoulMap() {
               </text>
             </g>
           ))}
-          {clickCityNum !== null && (
+          {cities.length !== 0 && currentCityIndex !== null && (
             <>
               <path
-                id={cities[clickCityNum].properties.SIG_KOR_NM}
-                d={cities[clickCityNum].properties.coord}
+                id={cities[currentCityIndex].properties.SIG_KOR_NM}
+                d={cities[currentCityIndex].properties.coord}
                 onClick={selectCity}
-                fill={fillCity(cities[clickCityNum])}
+                fill={fillCity(cities[currentCityIndex])}
                 className="selected"
               />
-              <text transform={nameCity(clickCityNum)} textAnchor="middle" className="name">
-                {cities[clickCityNum].properties.SIG_KOR_NM}
+              <text transform={nameCity(currentCityIndex)} textAnchor="middle" className="name">
+                {cities[currentCityIndex].properties.SIG_KOR_NM}
               </text>
             </>
           )}
         </svg>
       </div>
 
-      <h2 ref={nameRef}> 지금 서울은? </h2>
+      <h2>
+        지금 {currentCity.cityName_KOR}
+        {currentCity.cityName_KOR === '서울' ? '은' : '는'}?
+      </h2>
     </>
   );
 }


### PR DESCRIPTION
## 반영 브랜치 
feature/seoulmap -> develop

## 변경 사항
* 현재 선택된 지역 파악 방식을 변경했습니다

  * 이전: bool state로 서울/구 선택 여부를 판단, 문구 변경에 ref 사용
 
  * 현재: `currentCityIndex` 로 전역 상태(city)의 index만 가져와서 서울/구 선택 여부 판단(null이면 서울, 숫자면 구)

* redux-persist 도입으로 인해 새로고침 해도 선택된 지역이 날아가지 않습니다

* 변수 이름을 변경했습니다 (`clickCityNum` -> `currentCityIndex`)

## 테스트 결과
![test](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/f65d93c8-4b81-4b81-93ef-4ef756a6cc02)

(지도 날아가는 건 api 서버 요청에서 에러나서 그런거니까 무시 ㄱㄱ 새로고침해도 "노원구" 남아있는 것만 보면 됨!!) 