### PR TITLE
feat(Home): 로그인 상태에 따라 화면 이동 제한

### DIFF
--- a/src/components/SeoulMap.js
+++ b/src/components/SeoulMap.js
@@ -11,7 +11,9 @@ import { changeClickCity } from '../redux/citySlice';
 import '../css/SeoulMap.css';
 
 function SeoulMap() {
+  const currentMember = useSelector((state) => state.member);
   const currentCity = useSelector((state) => state.city);
+
   const dispatch = useDispatch();
 
   const navigate = useNavigate();
@@ -62,7 +64,11 @@ function SeoulMap() {
   };
 
   const onClickNotification = () => {
-    navigate('/notify');
+    if (currentMember.signed) {
+      navigate('/notify');
+    } else {
+      alert('로그인 모달');
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## 반영 브랜치
feature/home -> develop

## 변경 사항
* 로그인 안 한 상태면 알림 설정 페이지로 이동할 수 없습니다

  💥 근데 일단 모달 말고 alert만 띄움


## 테스트 결과
|로그인 ⭕|로그인 ❌|
|---|---|
|![test2](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/508fa058-2395-474d-a229-916bd9d273e6)|![test](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/66792ba9-0f46-4408-ad44-8475e65fff2e)|


