### PR TITLE
feat(Notification) : 알림 항목 관리 기능

### DIFF
--- a/src/components/OptionButton.jsx
+++ b/src/components/OptionButton.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import '../css/OptionButton.css';
+
+const OptionButton = ({ option, onChange, index, checked }) => {
+  const onChangeOption = (e) => {
+    onChange(e.target.checked, index);
+  };
+
+  return (
+    <div id="sub-category-container">
+      <input type="checkbox" onChange={onChangeOption} id={option} checked={checked} hidden />
+      <label htmlFor={option} id="sub-category-label">
+        <span> {option} </span>
+      </label>
+    </div>
+  );
+};
+
+export default OptionButton;

--- a/src/components/ToggleButton.jsx
+++ b/src/components/ToggleButton.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+import '../css/ToggleButton.css';
+
+const ToggleButton = ({ label, onChange, index }) => {
+  const [checked, setChecked] = useState(true);
+
+  const onChangeToggle = () => {
+    setChecked(!checked);
+    onChange(index);
+  };
+
+  return (
+    <div id="toggle-container">
+      <p> {label} </p>
+      <input type="checkbox" onChange={onChangeToggle} id={label} checked={checked} hidden />
+      <label htmlFor={label} className="toggleSwitch">
+        <span className="toggleButton"></span>
+      </label>
+    </div>
+  );
+};
+
+export default ToggleButton;

--- a/src/components/ToggleButton.jsx
+++ b/src/components/ToggleButton.jsx
@@ -1,23 +1,55 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
+import OptionButton from './OptionButton';
 import '../css/ToggleButton.css';
 
-const ToggleButton = ({ label, onChange, index }) => {
-  const [checked, setChecked] = useState(true);
+const ToggleButton = ({ label, onChange, index, options }) => {
+  const [checkedOption, setCheckedOption] = useState(options);
+  const checked = checkedOption.length > 0;
 
-  const onChangeToggle = () => {
-    setChecked(!checked);
+  const onChangeToggle = (e) => {
+    if (e.target.checked) {
+      setCheckedOption(options);
+    } else {
+      setCheckedOption([]);
+    }
     onChange(index);
   };
 
+  const onChangeOption = (optionChecked, optionIndex) => {
+    if (optionChecked) {
+      setCheckedOption([...checkedOption, options[optionIndex]]);
+    } else {
+      setCheckedOption(checkedOption.filter((option) => option !== options[optionIndex]));
+    }
+  };
+
+  useEffect(() => {
+    if (!checked) onChange(index);
+  }, [checked]);
+
   return (
-    <div id="toggle-container">
-      <p> {label} </p>
-      <input type="checkbox" onChange={onChangeToggle} id={label} checked={checked} hidden />
-      <label htmlFor={label} className="toggleSwitch">
-        <span className="toggleButton"></span>
-      </label>
-    </div>
+    <>
+      <div id="toggle-container">
+        <p> {label} </p>
+        <input type="checkbox" onChange={onChangeToggle} id={label} checked={checked} hidden />
+        <label htmlFor={label} className="toggleSwitch">
+          <span className="toggleButton"></span>
+        </label>
+      </div>
+
+      <div id="option-container">
+        {options.map((option, optionIndex) => (
+          <OptionButton
+            key={optionIndex}
+            option={option}
+            index={optionIndex}
+            onChange={onChangeOption}
+            checked={checkedOption.includes(options[optionIndex])}
+          />
+        ))}
+      </div>
+    </>
   );
 };
 

--- a/src/components/ToggleButton.jsx
+++ b/src/components/ToggleButton.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState, useRef } from 'react';
 
 import OptionButton from './OptionButton';
 import '../css/ToggleButton.css';
@@ -7,8 +7,10 @@ const ToggleButton = ({ label, onChange, index, options }) => {
   const [checkedOption, setCheckedOption] = useState(options);
   const checked = checkedOption.length > 0;
 
-  const onChangeToggle = (e) => {
-    if (e.target.checked) {
+  const toggleRef = useRef();
+
+  const onChangeToggle = () => {
+    if (toggleRef.current.checked) {
       setCheckedOption(options);
     } else {
       setCheckedOption([]);
@@ -21,18 +23,25 @@ const ToggleButton = ({ label, onChange, index, options }) => {
       setCheckedOption([...checkedOption, options[optionIndex]]);
     } else {
       setCheckedOption(checkedOption.filter((option) => option !== options[optionIndex]));
+      if (checkedOption.length === 1) {
+        toggleRef.current.checked = false;
+        onChangeToggle();
+      }
     }
   };
-
-  useEffect(() => {
-    if (!checked) onChange(index);
-  }, [checked]);
 
   return (
     <>
       <div id="toggle-container">
         <p> {label} </p>
-        <input type="checkbox" onChange={onChangeToggle} id={label} checked={checked} hidden />
+        <input
+          type="checkbox"
+          ref={toggleRef}
+          onChange={onChangeToggle}
+          id={label}
+          checked={checked}
+          hidden
+        />
         <label htmlFor={label} className="toggleSwitch">
           <span className="toggleButton"></span>
         </label>

--- a/src/css/Notification.css
+++ b/src/css/Notification.css
@@ -1,5 +1,5 @@
 #notification-page-container {
-  width: fit-content;
+  width: 275px;
   position: relative;
 }
 
@@ -13,6 +13,26 @@
 
 #onoff-box p {
   cursor: default;
+}
+
+#onoff-box > input[type='checkbox']:checked ~ .toggleSwitch {
+  background: #f7a8a4;
+}
+
+#onoff-box > input[type='checkbox']:checked ~ .toggleSwitch .toggleButton {
+  left: calc(100% - 20px);
+  background: #fff;
+}
+
+#notification-content-box {
+  height: 675px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  text-align: center;
 }
 
 #setting-submit-container {
@@ -31,4 +51,12 @@
 
   background-color: #6cb0ff;
   color: #fff;
+
+  cursor: pointer;
+}
+
+#notify-none {
+  color: #737373;
+  font-size: 16px;
+  font-weight: 700;
 }

--- a/src/css/Notification.css
+++ b/src/css/Notification.css
@@ -1,3 +1,23 @@
+#notification-page-container {
+  width: fit-content;
+  position: relative;
+}
+
+#onoff-box {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  padding: 0px 60px;
+}
+
+#setting-submit-container {
+  margin-top: 30px;
+
+  display: flex;
+  justify-content: end;
+}
+
 #setting-submit-button {
   width: 63px;
   height: 24px;
@@ -6,4 +26,5 @@
   border-radius: 5px;
 
   background-color: #6cb0ff;
+  color: #fff;
 }

--- a/src/css/Notification.css
+++ b/src/css/Notification.css
@@ -1,0 +1,9 @@
+#setting-submit-button {
+  width: 63px;
+  height: 24px;
+
+  border: none;
+  border-radius: 5px;
+
+  background-color: #6cb0ff;
+}

--- a/src/css/Notification.css
+++ b/src/css/Notification.css
@@ -11,6 +11,10 @@
   padding: 0px 60px;
 }
 
+#onoff-box p {
+  cursor: default;
+}
+
 #setting-submit-container {
   margin-top: 30px;
 

--- a/src/css/OptionButton.css
+++ b/src/css/OptionButton.css
@@ -11,6 +11,8 @@
   text-align: center;
 
   background: #d9d9d9;
+
+  cursor: pointer;
 }
 
 #sub-category-label span {

--- a/src/css/OptionButton.css
+++ b/src/css/OptionButton.css
@@ -3,11 +3,14 @@
 }
 
 #sub-category-label {
-  display: inline-block;
   width: 89px;
-  background: #d9d9d9;
+
+  display: inline-block;
+
   border-radius: 10px;
   text-align: center;
+
+  background: #d9d9d9;
 }
 
 #sub-category-label span {

--- a/src/css/OptionButton.css
+++ b/src/css/OptionButton.css
@@ -1,0 +1,19 @@
+#sub-category-container {
+  width: fit-content;
+}
+
+#sub-category-label {
+  display: inline-block;
+  width: 89px;
+  background: #d9d9d9;
+  border-radius: 10px;
+  text-align: center;
+}
+
+#sub-category-label span {
+  font-size: 13px;
+}
+
+#sub-category-container > input[type='checkbox']:checked ~ #sub-category-label {
+  background: #f7a8a4;
+}

--- a/src/css/ToggleButton.css
+++ b/src/css/ToggleButton.css
@@ -10,20 +10,25 @@
 .toggleSwitch {
   width: 50px;
   height: 22px;
+
   display: block;
   position: relative;
+
   border-radius: 15px;
   background-color: #d9d9d9;
+
   cursor: pointer;
 }
 
 .toggleSwitch .toggleButton {
   width: 17px;
   height: 17px;
+
   position: absolute;
   top: 50%;
   left: 3px;
   transform: translateY(-50%);
+
   border-radius: 50%;
   background: #fff;
 }
@@ -44,9 +49,11 @@
 
 #option-container {
   width: fit-content;
+
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   row-gap: 4px;
   column-gap: 4px;
+
   margin-bottom: 20px;
 }

--- a/src/css/ToggleButton.css
+++ b/src/css/ToggleButton.css
@@ -1,0 +1,43 @@
+#toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+#toggle-container p {
+  margin-right: 8px;
+}
+
+.toggleSwitch {
+  width: 50px;
+  height: 25px;
+  display: block;
+  position: relative;
+  border-radius: 15px;
+  background-color: #d9d9d9;
+  cursor: pointer;
+}
+
+.toggleSwitch .toggleButton {
+  width: 20px;
+  height: 20px;
+  position: absolute;
+  top: 50%;
+  left: 3px;
+  transform: translateY(-50%);
+  border-radius: 50%;
+  background: #fff;
+}
+
+#toggle-container > input[type='checkbox']:checked ~ .toggleSwitch {
+  background: #f7a8a4;
+}
+
+#toggle-container > input[type='checkbox']:checked ~ .toggleSwitch .toggleButton {
+  left: calc(100% - 23px);
+  background: #fff;
+}
+
+.toggleSwitch,
+.toggleButton {
+  transition: all 0.1s ease-in;
+}

--- a/src/css/ToggleButton.css
+++ b/src/css/ToggleButton.css
@@ -41,3 +41,12 @@
 .toggleButton {
   transition: all 0.1s ease-in;
 }
+
+#option-container {
+  width: fit-content;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  row-gap: 4px;
+  column-gap: 4px;
+  margin-bottom: 20px;
+}

--- a/src/css/ToggleButton.css
+++ b/src/css/ToggleButton.css
@@ -9,7 +9,7 @@
 
 .toggleSwitch {
   width: 50px;
-  height: 25px;
+  height: 22px;
   display: block;
   position: relative;
   border-radius: 15px;
@@ -18,8 +18,8 @@
 }
 
 .toggleSwitch .toggleButton {
-  width: 20px;
-  height: 20px;
+  width: 17px;
+  height: 17px;
   position: absolute;
   top: 50%;
   left: 3px;
@@ -33,7 +33,7 @@
 }
 
 #toggle-container > input[type='checkbox']:checked ~ .toggleSwitch .toggleButton {
-  left: calc(100% - 23px);
+  left: calc(100% - 20px);
   background: #fff;
 }
 

--- a/src/css/ToggleButton.css
+++ b/src/css/ToggleButton.css
@@ -1,6 +1,8 @@
 #toggle-container {
   display: flex;
   align-items: center;
+
+  width: 100%;
 }
 
 #toggle-container p {
@@ -57,5 +59,5 @@
   row-gap: 4px;
   column-gap: 4px;
 
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 }

--- a/src/css/ToggleButton.css
+++ b/src/css/ToggleButton.css
@@ -5,6 +5,8 @@
 
 #toggle-container p {
   margin-right: 8px;
+
+  cursor: default;
 }
 
 .toggleSwitch {

--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import notification from '../assets/notification.svg';
 import ToggleButton from '../components/ToggleButton';
@@ -7,6 +7,61 @@ import '../css/Notification.css';
 
 const Notification = () => {
   const MIDDLE_CATEGORY = ['자연재난', '사회재난', '지하철정보', '도로통제정보'];
+  const SUB_CATEGORY = [
+    [
+      '태풍',
+      '건조',
+      '산불',
+      '산사태',
+      '홍수',
+      '호우',
+      '폭염',
+      '안개',
+      '풍랑',
+      '미세먼지',
+      '대조기',
+      '가뭄',
+      '대설',
+      '지진해일',
+      '지진',
+      '한파',
+      '황사',
+      '강풍',
+      '기타 자연재난',
+    ],
+    [
+      '교통통제',
+      '화재',
+      '붕괴',
+      '폭발',
+      '교통사고',
+      '환경오염사고',
+      '에너지',
+      '통신',
+      '교통',
+      '금융',
+      '의료',
+      '수도',
+      '전염병',
+      '정전',
+      '가스',
+      '실종',
+      '기타 사회재난',
+    ],
+    [
+      '1호선',
+      '2호선',
+      '3호선',
+      '4호선',
+      '5호선',
+      '6호선',
+      '7호선',
+      '8호선',
+      '9호선',
+      '기타 지하철',
+    ],
+    ['도로사고', '집회/행사', '도로공사', '기타 도로통제'],
+  ];
 
   const [toggleStatus, setToggleStatus] = useState([true, true, true, true]);
   const notifyOn = toggleStatus.includes(true);
@@ -59,7 +114,13 @@ const Notification = () => {
 
       {notifyOn ? (
         MIDDLE_CATEGORY.map((category, index) => (
-          <ToggleButton key={index} label={category} onChange={handleToggleStatus} index={index} />
+          <ToggleButton
+            key={index}
+            label={category}
+            onChange={handleToggleStatus}
+            index={index}
+            options={SUB_CATEGORY[index]}
+          />
         ))
       ) : (
         <div> 현재 수신 받는 알림이 없습니다</div>

--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -1,7 +1,73 @@
-import React from 'react';
+import React, { useState } from 'react';
+
+import notification from '../assets/notification.svg';
+import ToggleButton from '../components/ToggleButton';
+
+import '../css/Notification.css';
 
 const Notification = () => {
-  return <div>알림 설정 페이지</div>;
+  const MIDDLE_CATEGORY = ['자연재난', '사회재난', '지하철정보', '도로통제정보'];
+
+  const [toggleStatus, setToggleStatus] = useState([true, true, true, true]);
+  const notifyOn = toggleStatus.includes(true);
+
+  const handleAllToggleStatus = (checked) => {
+    if (checked) {
+      setToggleStatus([true, true, true, true]);
+    } else {
+      setToggleStatus([false, false, false, false]);
+    }
+  };
+
+  const reverseToggleStatus = (index) => {
+    setToggleStatus(
+      toggleStatus.map((toggleChecked, toggleIndex) => {
+        return index === toggleIndex ? !toggleChecked : toggleChecked;
+      }),
+    );
+  };
+
+  const handleToggleStatus = (index) => {
+    reverseToggleStatus(index);
+  };
+
+  const onClickSave = () => {
+    const requestData = { notifyOn, toggleStatus };
+    console.log(requestData);
+  };
+
+  return (
+    <>
+      <div>
+        <img src={notification} width="30" />
+        <div id="toggle-container">
+          <p> 알림설정 </p>
+          <input
+            type="checkbox"
+            onChange={(e) => {
+              handleAllToggleStatus(e.target.checked);
+            }}
+            id="알림설정"
+            checked={notifyOn}
+            hidden
+          />
+          <label htmlFor="알림설정" className="toggleSwitch">
+            <span className="toggleButton"></span>
+          </label>
+        </div>
+      </div>
+
+      {notifyOn ? (
+        MIDDLE_CATEGORY.map((category, index) => (
+          <ToggleButton key={index} label={category} onChange={handleToggleStatus} index={index} />
+        ))
+      ) : (
+        <div> 현재 수신 받는 알림이 없습니다</div>
+      )}
+
+      <button onClick={onClickSave}> 저장 </button>
+    </>
+  );
 };
 
 export default Notification;

--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -126,7 +126,9 @@ const Notification = () => {
         <div> 현재 수신 받는 알림이 없습니다</div>
       )}
 
-      <button onClick={onClickSave}> 저장 </button>
+      <button id="setting-submit-button" onClick={onClickSave}>
+        저장
+      </button>
     </>
   );
 };

--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -110,19 +110,21 @@ const Notification = () => {
         </label>
       </div>
 
-      {notifyOn ? (
-        MIDDLE_CATEGORY.map((category, index) => (
-          <ToggleButton
-            key={index}
-            label={category}
-            onChange={handleToggleStatus}
-            index={index}
-            options={SUB_CATEGORY[index]}
-          />
-        ))
-      ) : (
-        <div> 현재 수신 받는 알림이 없습니다</div>
-      )}
+      <div id="notification-content-box">
+        {notifyOn ? (
+          MIDDLE_CATEGORY.map((category, index) => (
+            <ToggleButton
+              key={index}
+              label={category}
+              onChange={handleToggleStatus}
+              index={index}
+              options={SUB_CATEGORY[index]}
+            />
+          ))
+        ) : (
+          <div id="notify-none"> 현재 수신 받는 알림이 없습니다</div>
+        )}
+      </div>
 
       <div id="setting-submit-container">
         <button id="setting-submit-button" onClick={onClickSave}>

--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -92,24 +92,22 @@ const Notification = () => {
   };
 
   return (
-    <>
-      <div>
+    <div id="notification-page-container">
+      <div id="onoff-box">
         <img src={notification} width="30" />
-        <div id="toggle-container">
-          <p> 알림설정 </p>
-          <input
-            type="checkbox"
-            onChange={(e) => {
-              handleAllToggleStatus(e.target.checked);
-            }}
-            id="알림설정"
-            checked={notifyOn}
-            hidden
-          />
-          <label htmlFor="알림설정" className="toggleSwitch">
-            <span className="toggleButton"></span>
-          </label>
-        </div>
+        <p> 알림설정 </p>
+        <input
+          type="checkbox"
+          onChange={(e) => {
+            handleAllToggleStatus(e.target.checked);
+          }}
+          id="알림설정"
+          checked={notifyOn}
+          hidden
+        />
+        <label htmlFor="알림설정" className="toggleSwitch">
+          <span className="toggleButton"></span>
+        </label>
       </div>
 
       {notifyOn ? (
@@ -126,10 +124,12 @@ const Notification = () => {
         <div> 현재 수신 받는 알림이 없습니다</div>
       )}
 
-      <button id="setting-submit-button" onClick={onClickSave}>
-        저장
-      </button>
-    </>
+      <div id="setting-submit-container">
+        <button id="setting-submit-button" onClick={onClickSave}>
+          저장
+        </button>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 반영 브랜치
feature/notification-setting -> develop

✨ `feature/notification` 브랜치는 알림 수신 기능, `feature/notification-setting` 브랜치는 알림 수신항목 관리 기능을 담당

## 변경 사항
* 중분류 알림 on/off에 사용할 `ToggleButton` 컴포넌트를 추가, `Notification` 컴포넌트에 적용했습니다

  * "알림설정" 토글로 중분류 토글을 제어하는 기능을 추가했습니다
  
    * 알림설정 토글을 켤 경우, 모든 중분류 토글 on
    * 알림설정 토글을 끌 경우, 모든 중분류 토글 off
  
  * (알림설정 토글이 켜져있을 때) 중분류 토글 모두 끌 경우, "알림설정" 토글 off

* 소분류 알림 on/off에 사용할 `OptionButton` 컴포넌트를 추가, `ToggleButton` 컴포넌트에 적용했습니다

  * 중분류 토글로 소분류 버튼을 제어하는 기능을 추가했습니다. 세부 내용은 위와 동일합니다.
  
  * 특정 중분류 내 모든 소분류 버튼이 off 될 경우, 해당 중분류 토글이 off로 변합니다

## 테스트 결과
![test2](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/1ca7e8df-7e49-411b-b3c3-336303b4902a)

스타일링 수정하고 기능 다시 녹화하기 귀찮아서 사진만 남깁니다 ^^.. 기능은 변한 거 없어요
|on|off|
|---|---|
|![image](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/328cc1e0-8bdf-4249-a09d-47e905461af6)|![image](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/9f153d56-9e98-4fd3-9956-d7e1bbec81c3)|
