### PR TITLE
design(Signup): 로고 위치 수정

### DIFF
--- a/src/css/Signup.css
+++ b/src/css/Signup.css
@@ -61,8 +61,7 @@
   display: flex;
   justify-content: center;
 
-  position: absolute;
-  bottom: 40px;
+  margin-top: 60px;
 }
 
 #logo-container img {


### PR DESCRIPTION
## 반영 브랜치
feature/signup -> develop

## 변경 사항
* 로고 위치를 수정하여 세로 길이가 짧을 때 로고가 input을 침범하는 현상을 고쳤습니다.

## 테스트 결과
![logintest2](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/be15d6b7-b504-4fd8-b095-57e59c69f3a1)
