### PR TITLE
fix(Notification): api url 수정, 요청 헤더 추가

### DIFF
--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -7,7 +7,7 @@ import { getMessaging, getToken } from 'firebase/messaging';
 import notification from '../assets/notification.svg';
 import ToggleButton from '../components/ToggleButton';
 import { firebaseVapidKey } from '../data/firebaseConfig';
-
+import { getToken as getAccessToken } from '../utils/tokenUtil';
 import '../css/Notification.css';
 
 const Notification = () => {
@@ -16,6 +16,8 @@ const Notification = () => {
 
   const [toggleStatus, setToggleStatus] = useState([]);
   const [notifyOn, setNotifyOn] = useState(false);
+
+  const accessToken = getAccessToken();
 
   const navigate = useNavigate();
 
@@ -41,7 +43,6 @@ const Notification = () => {
 
   const onClickSave = () => {
     const requestData = {
-      memberId: 0,
       notifyOn,
       notificationList: [...notificationStatus].reduce((object, [key, value]) => {
         object[key] = value;
@@ -50,7 +51,11 @@ const Notification = () => {
     };
 
     try {
-      axios.post('https://api.bbiyong-bbiyong.seoul.kr/notification/save/topic', requestData);
+      axios.post('https://api.bbiyong-bbiyong.seoul.kr/topic', requestData, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
       navigate('/');
     } catch (e) {
       alert('설정 저장 중 에러가 발생했습니다! 잠시 후 다시 시도해주세요');
@@ -80,10 +85,13 @@ const Notification = () => {
       .catch((error) => {
         console.log('FCM 토큰 가져오기 오류 : ', error);
       });
+
     const getNotificationList = async () => {
-      const response = await axios.get(
-        'https://api.bbiyong-bbiyong.seoul.kr/notification/0/get/topic',
-      );
+      const response = await axios.get('https://api.bbiyong-bbiyong.seoul.kr/topic', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
 
       setNotificationStatus(
         Object.keys(response.data.data.notificationList).reduce((map, key) => {


### PR DESCRIPTION
## 반영 브랜치
feature/notification -> develop

## 변경 사항
* api url 수정 (노션 - 서버 위키 - 회원가입, 로그인에 이유 적혀있음)
* 저장된 알림 항목 받아오기, 알림 항목 저장 요청을 보낼 때 헤더에 jwt 토큰을 추가했습니다

## 테스트 결과
![test2](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/83ee8cdc-b23d-4afc-b0d0-da133bc2b61e)

