### PR TITLE
feat(Notification): FCM 토큰 서버 저장

### DIFF
--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -71,20 +71,26 @@ const Notification = () => {
   }, [toggleStatus]);
 
   useEffect(() => {
-    getToken(messaging, {
-      vapidKey: firebaseVapidKey,
-    })
-      .then((currentToken) => {
-        if (currentToken) {
-          console.log(currentToken);
-          // TODO: 서버에 토큰 전송
+    const getFCMToken = async () => {
+      try {
+        const token = await getToken(messaging, { vapidKey: firebaseVapidKey });
+        if (token) {
+          await axios.post(
+            'https://api.bbiyong-bbiyong.seoul.kr/notification/fcmtoken',
+            { token },
+            {
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+              },
+            },
+          );
         } else {
           console.log('FCM 토큰이 없습니다.');
         }
-      })
-      .catch((error) => {
-        console.log('FCM 토큰 가져오기 오류 : ', error);
-      });
+      } catch (error) {
+        alert('FCM 토큰 관련 에러가 발생했습니다. 잠시 후 다시 시도해주세요');
+      }
+    };
 
     const getNotificationList = async () => {
       const response = await axios.get('https://api.bbiyong-bbiyong.seoul.kr/topic', {
@@ -111,6 +117,7 @@ const Notification = () => {
       }
     };
 
+    getFCMToken();
     getNotificationList();
   }, []);
 


### PR DESCRIPTION
## 반영 브랜치
feature/notification-setting -> develop

## 변경 사항
* FCM 토큰을 서버에 저장하도록 요청을 보냅니다
* promise.then() 방식으로 쓰여져 있던 코드를 async/await을 사용하는 쪽으로 수정했습니다
* `currentToken` 변수는 `token`으로 이름을 수정했습니다 (사진 참고, api 요청쪽이랑 이름 통일했어요)

![image](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/e212e7b6-e9e6-4736-b981-126d14b5b313)

 
## 테스트 결과
눈에 보이는 변경사항은 없고 네트워크 탭 가면 요청 하나 보내는 거 확인 가넝
![image](https://github.com/bbiyongbbiyong/bbiyong-front/assets/87255462/4e8425ca-a756-42f5-9c2b-6b9910bee315)
